### PR TITLE
Feature/content view/quick start button design

### DIFF
--- a/SoundPost/SoundPost/ViewModels/ContentViewModel.swift
+++ b/SoundPost/SoundPost/ViewModels/ContentViewModel.swift
@@ -3,37 +3,80 @@ import SwiftUICore
 
 final class ContentViewModel: ObservableObject {
     
-    @Published private var tabSelection: Tab = .home
     @Published private var preTab: Tab = .home
+    @Published var isQuickStartButtonOn: Bool = false
     @Published var QuickStartButtonClick: Int = 0
+    @Published var isShowingNewPost: Bool = false
     
-    @Published var tabHandler: Tab = .home {
-        didSet(oldTab) {
-            if self.tabHandler != .quickStart && self.QuickStartButtonClick == 0 {
-                self.preTab = self.tabSelection
-            }
-            if self.QuickStartButtonClick == 4 {
-                self.tabHandler = self.preTab
-            }
-        }
-        willSet(newTab) {
-            if newTab == .quickStart {
-                if self.QuickStartButtonClick >= 0 && self.QuickStartButtonClick < 4 {
-                    self.QuickStartButtonClick += 1
-                } else {
-                    self.QuickStartButtonClick = 0
-                }
-            } else {
-                self.QuickStartButtonClick = 0
-            }
-            self.tabSelection = newTab
-        }
-        
+    @Published var tabHandler: Tab = .home
+//    {
+////        didSet(oldTab) {
+////            if self.tabHandler != .quickStart && self.QuickStartButtonClick == 0 {
+////                self.preTab = oldTab
+////            }
+////            if self.QuickStartButtonClick == 4 {
+////                self.tabHandler = self.preTab
+////            }
+////        }
+////        willSet(newTab) {
+////            if newTab == .quickStart {
+////                if self.QuickStartButtonClick >= 0 && self.QuickStartButtonClick < 4 {
+////                    self.QuickStartButtonClick += 1
+////                } else {
+////                    self.QuickStartButtonClick = 0
+////                }
+////            } else {
+////                self.QuickStartButtonClick = 0
+////            }
+////        }
+//        get { self.preTab }
+//        set {
+//            if isQuickStartButtonOn {
+//                
+//            }
+//        }
+//        
+//    }
+    
+    final func isNewPostShowing() -> Bool {
+        return !isShowingNewPost
     }
     
+    final func QuickStartButtonColor() -> Color {
+        return isQuickStartButtonOn ? .black : .gray
+    }
+    final func TabColor(_ tab: Tab) -> Color {
+        if isQuickStartButtonOn { return .gray }
+        else { return tab == self.tabHandler ? .black : .gray }
+    }
+    final func TabSet(_ tab: Tab) {
+        self.tabHandler = tab
+        if isQuickStartButtonOn {
+            isShowingNewPost = false
+            isQuickStartButtonOn = false
+            QuickStartButtonClick = 0
+            
+        }
+    }
+    final func QuickStartSet() {
+        if isQuickStartButtonOn {
+            self.isShowingNewPost = true
+            if self.QuickStartButtonClick >= 0 && self.QuickStartButtonClick < 3 {
+                self.QuickStartButtonClick += 1
+            } else {
+                self.isShowingNewPost = false
+                self.QuickStartButtonClick = 0
+                self.isQuickStartButtonOn = false
+            }
+        } else {
+            self.isQuickStartButtonOn = true
+            self.isShowingNewPost = true
+            self.QuickStartButtonClick += 1
+        }
+    }
     enum Tab: Hashable {
         case home
-        case quickStart
+//        case quickStart
         case myProfile
     }
 }

--- a/SoundPost/SoundPost/Views/ContentView/ContentView.swift
+++ b/SoundPost/SoundPost/Views/ContentView/ContentView.swift
@@ -4,20 +4,26 @@ import Firebase
 struct ContentView: View {
     @StateObject private var contentViewModel = ContentViewModel()
     var body: some View {
-        VStack {
-            switch contentViewModel.tabHandler {
-            case .home:
-//                HomeView()
-                TestUIView()
-            case .myProfile:
-//                QuickStartButtonView()
-                TestUIView()
-            case .quickStart:
-//                MyProfileView()
-                TestUIView()
-
+        ZStack {
+            VStack {
+                switch contentViewModel.tabHandler {
+                case .home:
+                    //                HomeView()
+                    TestUIView()
+                    
+                case .myProfile:
+                    //                MyProfileView()
+                    TestUIView()
+                    
+                }
             }
-            CustomTabView(contentViewModel: contentViewModel)
+            VStack {
+                if contentViewModel.isShowingNewPost {
+                    QuickStartButtonView(contentViewModel: contentViewModel)
+                }
+                Spacer()
+                CustomTabView(contentViewModel: contentViewModel)
+            }
         }
     }
 }

--- a/SoundPost/SoundPost/Views/ContentView/ContentView.swift
+++ b/SoundPost/SoundPost/Views/ContentView/ContentView.swift
@@ -4,28 +4,25 @@ import Firebase
 struct ContentView: View {
     @StateObject private var contentViewModel = ContentViewModel()
     var body: some View {
-        ZStack {
             VStack {
-                switch contentViewModel.tabHandler {
-                case .home:
-                    //                HomeView()
-                    TestUIView()
-                    
-                case .myProfile:
-                    //                MyProfileView()
-                    TestUIView()
-                    
-                }
-            }
-            VStack {
-                if contentViewModel.isShowingNewPost {
-                    QuickStartButtonView(contentViewModel: contentViewModel)
+                ZStack{
+                    switch contentViewModel.tabHandler {
+                    case .home:
+                        //HomeView()
+                        TestUIView()
+                        
+                    case .myProfile:
+                        //MyProfileView()
+                        TestUIView2()
+                    }
+                        if contentViewModel.isShowingNewPost {
+                            QuickStartButtonView(contentViewModel: contentViewModel)
+                        }
                 }
                 Spacer()
                 CustomTabView(contentViewModel: contentViewModel)
             }
         }
-    }
 }
     
     #Preview {

--- a/SoundPost/SoundPost/Views/ContentView/CustomTabView.swift
+++ b/SoundPost/SoundPost/Views/ContentView/CustomTabView.swift
@@ -75,11 +75,11 @@ struct CustomTabView: View {
                 }
                 Spacer()
             }
-            .frame(width: UIScreen.main.bounds.width, height: 85)
+            .frame(width: UIScreen.main.bounds.width, height: 80)
             .background(
                 RoundedRectangle(cornerRadius: 0)
                     .fill(.white)
-                    .frame(width: UIScreen.main.bounds.width, height: 85)
+                    .frame(width: UIScreen.main.bounds.width, height: 80)
             )
             .edgesIgnoringSafeArea(.bottom)
     }

--- a/SoundPost/SoundPost/Views/ContentView/CustomTabView.swift
+++ b/SoundPost/SoundPost/Views/ContentView/CustomTabView.swift
@@ -8,22 +8,22 @@ struct CustomTabView: View {
             HStack {
                 Spacer()
                 Button {
-                    contentViewModel.tabHandler = .home
+                    contentViewModel.TabSet(.home)
                 } label: {
                     VStack {
                         Image(systemName: "house.fill")
-                            .foregroundColor(contentViewModel.tabHandler == .home ? .black : .gray)
+                            .foregroundColor(contentViewModel.TabColor(.home))
                             .font(.title)
                         
                         Text("홈")
-                            .foregroundColor(contentViewModel.tabHandler == .home ? .black : .gray)
+                            .foregroundColor(contentViewModel.TabColor(.home))
                             .font(.caption)
                     }
                 }
                 Spacer()
                 Spacer()
                 Button {
-                    contentViewModel.tabHandler = .quickStart
+                    contentViewModel.QuickStartSet()
                 } label: {
                     VStack {
                         switch contentViewModel.QuickStartButtonClick {
@@ -45,15 +45,15 @@ struct CustomTabView: View {
                             Image(systemName: "record.circle")
                                 .foregroundColor(.red)
                                 .font(.title)
-                            Text("멈춤")
+                            Text("재녹음")
                                 .foregroundColor(.red)
                                 .font(.caption)
                         default:
                             Image(systemName: "plus.circle.fill")
-                                .foregroundColor(contentViewModel.tabHandler == .quickStart ? .black : .gray)
+                                .foregroundColor(contentViewModel.QuickStartButtonColor())
                                 .font(.title)
                             Text("포스팅")
-                                .foregroundColor(contentViewModel.tabHandler == .quickStart ? .black : .gray)
+                                .foregroundColor(contentViewModel.QuickStartButtonColor())
                                 .font(.caption)
                         }
                     }
@@ -61,23 +61,27 @@ struct CustomTabView: View {
                 Spacer()
                 Spacer()
                 Button {
-                    contentViewModel.tabHandler = .myProfile
+                    contentViewModel.TabSet(.myProfile)
                 } label: {
                     VStack {
                         Image(systemName: "person.fill")
-                            .foregroundColor(contentViewModel.tabHandler == .myProfile ? .black : .gray)
+                            .foregroundColor(contentViewModel.TabColor(.myProfile))
                             .font(.title)
                         
                         Text("프로필")
-                            .foregroundColor(contentViewModel.tabHandler == .myProfile ? .black : .gray)
+                            .foregroundColor(contentViewModel.TabColor(.myProfile))
                             .font(.caption)
                     }
                 }
                 Spacer()
             }
-//            .frame(width: UIScreen.main.bounds.width, height: 85)
+            .frame(width: UIScreen.main.bounds.width, height: 85)
+            .background(
+                RoundedRectangle(cornerRadius: 0)
+                    .fill(.white)
+                    .frame(width: UIScreen.main.bounds.width, height: 85)
+            )
             .edgesIgnoringSafeArea(.bottom)
-
     }
 }
 

--- a/SoundPost/SoundPost/Views/ContentView/QuickStartButtonView.swift
+++ b/SoundPost/SoundPost/Views/ContentView/QuickStartButtonView.swift
@@ -1,0 +1,130 @@
+import SwiftUI
+
+struct QuickStartButtonView: View {
+    @StateObject var contentViewModel: ContentViewModel
+    var body: some View {
+        VStack {
+            Spacer()
+            //tab선택에 따른 뷰 변경
+            switch contentViewModel.QuickStartButtonClick {
+            case 1 :
+                SelectRecordView()
+            case 2 :
+                RecordingView()
+            case 3 :
+                SelectView()
+            default :
+                TestUIView()
+            }
+        }
+        .padding(.bottom, 10)
+    }
+}
+
+struct SelectView: View {
+    var body: some View {
+            HStack {
+                Spacer()
+                VStack {
+                    //이미지 들어갈 곳
+                    RoundedRectangle(cornerRadius: 5)
+                        .fill(Color.green)
+                        .frame(width: 60, height: 60)
+                    Button {
+                        
+                    } label: {
+                        Text("이미지 선택")
+                            .foregroundStyle(.black)
+                    }
+                    .padding()
+                    .buttonBorderShape(.roundedRectangle(radius: 10))
+                    .buttonStyle(.borderedProminent)
+                    .tint(.primaryNeon.opacity(1))
+                }
+                Spacer()
+                VStack {
+                    RoundedRectangle(cornerRadius: 5)
+                        .fill(Color.clear)
+                        .frame(width: 60, height: 60)
+                    Button {
+                        
+                    } label: {
+                        Text("게시")
+                            .foregroundStyle(.black)
+                    }
+                    .padding()
+                    .buttonBorderShape(.roundedRectangle(radius: 10))
+                    .buttonStyle(.borderedProminent)
+                    .tint(.primaryNeon.opacity(1))
+                }
+                Spacer()
+                VStack {
+                    RoundedRectangle(cornerRadius: 5)
+                        .fill(Color.clear)
+                        .frame(width: 60, height: 60)
+                    Button {
+                        
+                    } label: {
+                        Text("다시 듣기")
+                            .foregroundStyle(.black)
+                    }
+                    .padding()
+                    .buttonBorderShape(.roundedRectangle(radius: 10))
+                    .buttonStyle(.borderedProminent)
+                    .tint(.primaryNeon.opacity(1))
+                }
+                Spacer()
+            }
+    }
+}
+
+struct SelectRecordView: View {
+    var body: some View {
+        HStack {
+            Spacer()
+            VStack {
+                //이미지 들어갈 곳
+                RoundedRectangle(cornerRadius: 5)
+                    .fill(Color.green)
+                    .frame(width: 60, height: 60)
+                Button {
+                    
+                } label: {
+                    Text("이미지 선택")
+                        .foregroundStyle(.black)
+                }
+                .padding()
+                .buttonBorderShape(.roundedRectangle(radius: 10))
+                .buttonStyle(.borderedProminent)
+                .tint(.primaryNeon.opacity(1))
+            }
+            Spacer()
+            VStack {
+                RoundedRectangle(cornerRadius: 5)
+                    .fill(Color.clear)
+                    .frame(width: 60, height: 60)
+                Button {
+                    
+                } label: {
+                    Text("녹음파일 선택")
+                        .foregroundStyle(.black)
+                }
+                .padding()
+                .buttonBorderShape(.roundedRectangle(radius: 10))
+                .buttonStyle(.borderedProminent)
+                .tint(.primaryNeon.opacity(1))
+            }
+            Spacer()
+        }
+    }
+}
+
+struct RecordingView: View {
+    var body: some View {
+        HStack {
+            //음성 인식 파형이 그려질 공간
+            RoundedRectangle(cornerRadius: 20)
+                .frame(width: UIScreen.main.bounds.width - 20, height: UIScreen.main.bounds.height / 7)
+        }
+    }
+}

--- a/SoundPost/SoundPost/Views/ContentView/QuickStartButtonView.swift
+++ b/SoundPost/SoundPost/Views/ContentView/QuickStartButtonView.swift
@@ -3,21 +3,23 @@ import SwiftUI
 struct QuickStartButtonView: View {
     @StateObject var contentViewModel: ContentViewModel
     var body: some View {
-        VStack {
-            Spacer()
-            //tab선택에 따른 뷰 변경
-            switch contentViewModel.QuickStartButtonClick {
-            case 1 :
-                SelectRecordView()
-            case 2 :
-                RecordingView()
-            case 3 :
-                SelectView()
-            default :
-                TestUIView()
+        ZStack {
+            Color.gray.opacity(0.3)
+            VStack {
+                Spacer()
+                //tab선택에 따른 뷰 변경
+                switch contentViewModel.QuickStartButtonClick {
+                case 1 :
+                    SelectRecordView()
+                case 2 :
+                    RecordingView()
+                case 3 :
+                    SelectView()
+                default :
+                    TestUIView()
+                }
             }
         }
-        .padding(.bottom, 10)
     }
 }
 
@@ -126,5 +128,6 @@ struct RecordingView: View {
             RoundedRectangle(cornerRadius: 20)
                 .frame(width: UIScreen.main.bounds.width - 20, height: UIScreen.main.bounds.height / 7)
         }
+        .padding(.bottom)
     }
 }

--- a/SoundPost/SoundPost/Views/ContentView/TestUIView.swift
+++ b/SoundPost/SoundPost/Views/ContentView/TestUIView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct TestUIView: View {
     var body: some View {
         VStack {
-            Color.gray
+            Color.blue.opacity(0.3)
         }
     }
 }

--- a/SoundPost/SoundPost/Views/ContentView/TestUIView2.swift
+++ b/SoundPost/SoundPost/Views/ContentView/TestUIView2.swift
@@ -1,0 +1,20 @@
+//
+//  TestUIView.swift
+//  SoundPost
+//
+//  Created by 최하진 on 3/7/25.
+//
+
+import SwiftUI
+
+struct TestUIView2: View {
+    var body: some View {
+        VStack {
+            Color.red.opacity(0.6)
+        }
+    }
+}
+
+#Preview {
+    TestUIView2()
+}


### PR DESCRIPTION
퀵스타트버튼을 탭 버튼에서 일반 버튼으로 수정
- 기본 탭 뷰 위에 버튼이 뜨도록 위치 변경
- 그에 맞게 contentViewModel, customTabView 수정
- 멈춤->재녹음으로 텍스트 수정 완료

[QuickStartButtonView 작업 내용]
- 뒷 탭배경 딤드처리 추가
- 탭 시 이미지선택, 녹음파일 선택 버튼 표출
- 색상변경된 상태에서 탭 시 녹음 시작, 상단 버튼 사라지고 녹음 파형 이미지 표출(이미지 추후 추가)
- 녹음 중일 경우 버튼 탭 하는 경우 녹음 종료되고 버튼 세개 표출 ’이미지 선택’, ‘게시’, ‘듣기’

+ 뒷배경 딤드 터치시 사라짐는 차후에 추가할 예정

![스크린샷 2025-03-07 오후 9 07 51](https://github.com/user-attachments/assets/73283f8d-5961-4fd3-9031-42f485cf5d45)

탭 시 이미지선택, 녹음파일 선택 버튼 표출
![스크린샷 2025-03-07 오후 9 41 04](https://github.com/user-attachments/assets/02b1b0fb-972e-4f88-8089-78b4fba507c6)

색상변경된 상태에서 탭 시 녹음 시작, 상단 버튼 사라지고 녹음 파형 이미지 표출(이미지 추후 추가)
![스크린샷 2025-03-07 오후 9 41 10](https://github.com/user-attachments/assets/1cf881c7-1d4b-47ab-aa4c-e3feb74069f6)

녹음 중일 경우 버튼 탭 하는 경우 녹음 종료되고 버튼 세개 표출 ’이미지 선택’, ‘게시’, ‘듣기’
![스크린샷 2025-03-07 오후 9 41 17](https://github.com/user-attachments/assets/632e02bb-1b3a-4b5e-8df6-6d12816ad5a3)
